### PR TITLE
Added - accessors to texture width/height in SpoutSenders

### DIFF
--- a/Assets/SpoutSender.cs
+++ b/Assets/SpoutSender.cs
@@ -9,6 +9,9 @@ namespace Klak.Spout
         [SerializeField] int _width = 1280;
         [SerializeField] int _height = 720;
 
+        public int Width { get { return _width; } set { _width = value; } }
+        public int Height { get { return _height; } set { _height = value; } }
+
         #endregion
 
         #region Private resources

--- a/Assets/SpoutSender.cs
+++ b/Assets/SpoutSender.cs
@@ -58,7 +58,13 @@ namespace Klak.Spout
             }
 
             if (_sharedTexture != null)
-                Graphics.CopyTexture(_renderTarget, _sharedTexture);
+            {
+                if (_renderTarget.IsCreated())
+                {
+                    Graphics.CopyTexture(_renderTarget, _sharedTexture);
+                }
+            } 
+                
         }
 
         #endregion


### PR DESCRIPTION
Allowing the sender size to be changed during runtime