### PR TITLE
SpoutSender can have a SenderName different from GameObject

### DIFF
--- a/Assets/Klak/Spout/Editor/SpoutSenderEditor.cs
+++ b/Assets/Klak/Spout/Editor/SpoutSenderEditor.cs
@@ -11,11 +11,13 @@ namespace Klak.Spout
     sealed class SpoutSenderEditor : Editor
     {
         SerializedProperty _sourceTexture;
+        SerializedProperty _senderName;
         SerializedProperty _alphaSupport;
 
         void OnEnable()
         {
             _sourceTexture = serializedObject.FindProperty("_sourceTexture");
+            _senderName = serializedObject.FindProperty("_senderName");
             _alphaSupport = serializedObject.FindProperty("_alphaSupport");
         }
 
@@ -50,6 +52,8 @@ namespace Klak.Spout
             else
                 EditorGUILayout.PropertyField(_sourceTexture);
 
+
+            EditorGUILayout.PropertyField(_senderName);
             EditorGUILayout.PropertyField(_alphaSupport);
 
             serializedObject.ApplyModifiedProperties();


### PR DESCRIPTION
Re-create plugin if the name changed.